### PR TITLE
Improve table styling and use consistent page font

### DIFF
--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -11,7 +11,7 @@ layout: default
           {% include conference_navi_left.html %}
 
         </td>
-        <td valign='top' style='width:70%; font-family:verdana; font-size:12pt;'>
+        <td valign='top' style='width:70%; font-size:12pt;'>
           <div class='page-section' id='page'>
             <br>
             <br>

--- a/_layouts/conference.html
+++ b/_layouts/conference.html
@@ -19,6 +19,7 @@ layout: default
 
               {{ content }}
 
+          </div>
         </td>
         <td  valign='top' style='width:5%;' >
         </td>

--- a/css/style.css
+++ b/css/style.css
@@ -66,3 +66,23 @@ footer{color:#949597;background#3a3a3a;border-top:1px solid #1a2644;}
     #mainpage .mainpageboxlarge .mainpageboxheadline{font-size:18px;}
     #mainpage .mainpageboxsmall .mainpageboxheadline{font-size:12px;}
 }
+
+#page table {
+    border-collapse: collapse;
+    border-top: 2px solid #626878;
+    border-bottom: 2px solid #626878;
+}
+
+#page th, td {
+    padding: 10px 5px;
+    vertical-align: baseline;
+}
+
+#page th {
+    border-bottom: 2px solid #626878;
+}
+
+#page tr {
+    border-bottom: 1px solid #626878;
+}
+


### PR DESCRIPTION
This makes tables in conference pages (such as the attendee list) more readable.

Conference page content now also uses the same font as the other DENOG pages and the surrounding navigation elements.