### PR TITLE
Fix typos

### DIFF
--- a/de/index.md
+++ b/de/index.md
@@ -26,7 +26,7 @@ redirect_from: "/"
 
             <div class="mainpagepaddedbox">
               <h3>Über Denog</h3>
-              <p>DENOG ist eine Community für Menschen, die am Internet in Deutschland forschen, es betreiben und weiter entwickeln. Im Rahmen dieses technischen Forums treffen sich Menschen, die mit, für oder am Internet arbeiten und netzwerkspezifische Themen mit gleichgesinnten diskutieren, um sie dadurch einfacher lösen zu können.</p>
+              <p>DENOG ist eine Community für Menschen, die am Internet in Deutschland forschen, es betreiben und weiter entwickeln. Im Rahmen dieses technischen Forums treffen sich Menschen, die mit, für oder am Internet arbeiten und netzwerkspezifische Themen mit Gleichgesinnten diskutieren, um sie dadurch einfacher lösen zu können.</p>
               <a href="{{ site.url }}/{{ page.lang }}/informationen.html" class="btn btn-custom-default pull-right">Mehr erfahren <i class="ion-arrow-right-    c"></i></a>
               <div class="clearfix"></div>
             </div>

--- a/de/informationen.md
+++ b/de/informationen.md
@@ -26,8 +26,8 @@ Das Haupt-Organ der DENOG-Online-Präsenz ist die Mailingliste. Hier werden inte
 
 ## IRC-Channel
 
-IRC steht für Internet Relay Chat und ist ein Protokoll, das Echtzeitkommnukation in verschiedenen (Themen)Kanälen ermöglicht. 
-Um sich mit anderen DENOG-Aktiven im IRC unterhalten zu können, benötigt man zunächst einen IRC Client. Für Windows-User empfiehlt sich die Nutzung des weit verbreiteten IRC Clients mIRC, Linux/Unix-User verwenden desöfteren die Clients irssi, EPIC oder BitchX , für Benutzer von Mac OS X empfiehlt sich LimeChat oder Colloquy.
+IRC steht für Internet Relay Chat und ist ein Protokoll, das Echtzeitkommunikation in verschiedenen (Themen)Kanälen ermöglicht. 
+Um sich mit anderen DENOG-Aktiven im IRC unterhalten zu können, benötigt man zunächst einen IRC Client. Für Windows-User empfiehlt sich die Nutzung des weit verbreiteten IRC Clients mIRC, Linux/Unix-User verwenden desöfteren die Clients irssi, EPIC oder BitchX, für Benutzer von Mac OS X empfiehlt sich LimeChat oder Colloquy.
 
 DENOG-Teilnehmer treffen sich in einem eigenen Channel mit dem Namen #DENOG im IRCNet, wo zu fast jeder Tageszeit jemand anzutreffen ist. Eine Übersicht der Stammchatter findet sich [hier](chatterliste_iframe.html).
 


### PR DESCRIPTION
This PR fixes a few typos that I found while reading through the website. Under [`Informationen`](https://www.denog.de/de/informationen.html) the sentence `Mehr Informationen zu DENOG-Meetings finden sich hier.` also seems to miss a link, but I’m not sure where to.

Cheers