### PR TITLE
Responsive: fix mainpage box and navbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 header{min-height:70px;}
-.navbar.navbar-default{width:100%;height:70px;color:#000000;background:#ffffff;box-shadow:0px 0px 15px 0px #f1f1f1;}
+.navbar.navbar-default{width:100%;color:#000000;background:#ffffff;box-shadow:0px 0px 15px 0px #f1f1f1;}
 .navbar.navbar-default .navbar-collapse{background:#ffffff;}
 .navbar.navbar-default .collapse.in{position:relative;z-index:5000;}
 .navbar-brand img{position: relative;display:inline;left:0px;}
@@ -43,13 +43,14 @@ hr.verticaldivider{margin:40px 0px 0px 0px;border-top:2px solid #f9cd00;}
 footer{color:#949597;background#3a3a3a;border-top:1px solid #1a2644;}
 
 #mainpage .mainpagebox{background:url(../images/exhibition2016.jpg) center center;position:relative;}
+#mainpage .mainpagebox > div > .container{padding-top:10px;padding-bottom:10px;}
 #mainpage .mainpageboxsmall{margin-top:20px;}
 #mainpage .mainpagebox .mainpageboxlink{width:25px;height:25px;line-height:24px;right:8px;bottom:8px;margin:0px;padding:0px;font-size:20px;text-align:center;position:absolute;}
 #mainpage .mainpagebox > div{background:rgba(230,230,230,0.95);}
-#mainpage .mainpagebox #mainpagelogo{width:100%;max-width:440px;margin:20px auto 20px auto;display:block;}
+#mainpage .mainpagebox #mainpagelogo{width:100%;max-width:400px;margin:20px auto 20px auto;display:block;}
 #mainpage .mainpagebox .mainpageboxheadline{color:#3a393a;text-align:center;}
 #mainpage .mainpagebox .mainpageboxheadline + p{padding:20px 0px 20px 0px;text-align:center;}
-#mainpage .mainpageboxlarge .mainpageboxheadline{margin:0px;padding:40px 0px 40px 0px;font-size:22px;}
+#mainpage .mainpageboxlarge .mainpageboxheadline{margin:0px;padding:30px 0px 20px 0px;font-size:22px;}
 #mainpage .mainpageboxsmall .mainpageboxheadline{margin:0px;padding:80px 0px 80px 0px;font-size:16px;}
 #mainpage .mainpagepaddedbox{padding:20px;text-align:justify;}
 
@@ -78,6 +79,9 @@ footer{color:#949597;background#3a3a3a;border-top:1px solid #1a2644;}
     #footertopbadge #footertopbadgetext{font-size:16px;}
     #mainpage .mainpageboxlarge .mainpageboxheadline{font-size:20px;}
     #mainpage .mainpageboxsmall .mainpageboxheadline{font-size:14px;}
+}
+@media (min-width: 786px) and (max-width: 992px) {
+    .navbar-right{margin-left:-40px;margin-right:-40px;}
 }
 @media (max-width: 992px) {
     #footertopbadge #footertopbadgetext{font-size:12px;}

--- a/de/index.md
+++ b/de/index.md
@@ -9,8 +9,8 @@ redirect_from: "/"
             <div>
                 <div class="container">
                     <div class="row">
-                        <div class="col-sm-6">
-                             <a href="{{ site.url }}/{{ page.lang }}/meetings/denog13/index.html" class="btn btn-custom-default mainpagelogobtn pull-right"><img src="{{ site.url }}/images/logos/denog13.png" id="mainpagelogo" /></a>
+                        <div class="col-md-6 col-sm-12">
+                             <a href="{{ site.url }}/{{ page.lang }}/meetings/denog13/index.html" class="btn btn-custom-default mainpagelogobtn float-md-right"><img src="{{ site.url }}/images/logos/denog13.png" id="mainpagelogo" /></a>
                         </div>
                         <div class="col-md-6 col-sm-12">
                         <h2 class="mainpageboxheadline">Unterstütze die DENOG e.V.</h2>


### PR DESCRIPTION
Somehow during merge the responsive fix for the mainpagebox broke. Fixed this.
Also in the meantime the navbar broke on viewports between 786px and 992px width because an item got longer. Fixed this with a workaround.