### PR TITLE
rewording to 'past'

### DIFF
--- a/de/meetings/denog11/index.md
+++ b/de/meetings/denog11/index.md
@@ -12,8 +12,11 @@ meeting: DENOG11
 <center>
 
 
-<h1>DENOG 11 findet vom 10. - 12. November 2019 in Hamburg statt.</h1>
+<h1>DENOG 11 fand vom 10. - 12. November 2019 in Hamburg statt.</h1>
 
+<i><b>Note: the event took place in the past, the below content was preserved for historical purposes</b></i>
+
+ 
 </center>
  <br><br>
  

--- a/de/meetings/denog12/index.md
+++ b/de/meetings/denog12/index.md
@@ -10,8 +10,11 @@ meeting: DENOG12
 
 <br><br>
 <center>
-    <h1>DENOG12 will happen virtually from November 8. to November 10.</h1>
+    <h1>DENOG12 happened virtually from November 8. to November 10. 2020</h1>
 </center>
+<i><b>Note: the event took place in the past, the below content was preserved for historical purposes</b></i>
+
+
 <br>
 Due to the ongoing COVID-19 situation DENOG12 will happen virtually. We will start the conference with a workshop day Sunday, November 8th.
 On Monday & Tuesday (November 9/10) the usual conference will take place with (lightning-)talks, chats, group discussions and a chance to meet our sponsors.

--- a/de/meetings/denog13/index.md
+++ b/de/meetings/denog13/index.md
@@ -23,11 +23,6 @@ Please find more information and details below, to support you in planning and o
 <br /> 
 <br /> 
 
-## Not Registered Yet?
-Last Minute Tickets are still available at <a href="https://www.denog.de/de/meetings/denog13/tickets.html">Tickets</a>.
-<br />
-<br />
-
 
 ## Tuesday 09th Nov 2021 - Conference Agenda
 <br /> 

--- a/de/meetings/denog13/index.md
+++ b/de/meetings/denog13/index.md
@@ -10,8 +10,11 @@ meeting: DENOG13
 
 <br><br>
 <center>
-    <h1>DENOG13 will happen virtually from November 7. to November 09. 2021</h1>
+    <h1>DENOG13 happened virtually from November 7. to November 09. 2021</h1>
 </center>
+
+<i><b>Note: the event took place in the past, the below content was preserved for historical purposes</b></i>
+
 <br>
 Due to the ongoing COVID-19 situation DENOG13 will happen <u>virtually</u>. We will start the conference with a <b>workshop day Sunday</b>, November 7th.
 On <b>Monday & Tuesday</b> (November 8/9) the usual conference will take place with (lightning-)talks, chats, group discussions and a chance to meet our sponsors.

--- a/de/meetings/denog13/tickets.md
+++ b/de/meetings/denog13/tickets.md
@@ -5,6 +5,7 @@ title: DENOG13 - Tickets
 year: 2021
 city: virtual
 meeting: DENOG13
+hide: true
 ---
 <br/>
 <br/>

--- a/de/meetings/denog13/workshops.md
+++ b/de/meetings/denog13/workshops.md
@@ -5,6 +5,7 @@ title: DENOG13 - Workshop Registration
 year: 2021
 city: virtual
 meeting: DENOG13
+hide: true
 ---
 <br/>
 <br/>


### PR DESCRIPTION
some tiny rewordings to make sure the pages reflect their "it was in the past" status.

also hide registration menu items for tickets and workshops 
(frontmatter hide=true) should hide the items from the menu if I understand _includes/conference_navi_left.html correctly)