### PR TITLE
Meetup2024-04: define max-width as 100% for anfahrt pictures

### DIFF
--- a/de/events/meetup-2024-04.md
+++ b/de/events/meetup-2024-04.md
@@ -39,8 +39,8 @@ Alle Meetups aus 2024:
 | Wo    | Lab3, Hilpertstr. 31, 64295 Darmstadt |
 | Anfahrt | [https://www.lab3.org/anfahrt/](https://www.lab3.org/anfahrt/) |
 
-<img width="500px" src="/images/meetups/Anfahrt_LAB3eV.jpg" />
-<img width="500px" src="/images/meetups/LAB_Eingang.png" />  
+<img width="500px" src="/images/meetups/Anfahrt_LAB3eV.jpg" style="max-width: 100% "/>
+<img width="500px" src="/images/meetups/LAB_Eingang.png" style="max-width: 100% "/>  
 <br />
 <br />
 


### PR DESCRIPTION
This should help with some mobile device resoltions.

Defines that the pictures should only fill the full width even if it means that it's less then 500px.

Doesn't solve all quirks with scaling.